### PR TITLE
First version of package creation

### DIFF
--- a/rnp/rnp.nuspec
+++ b/rnp/rnp.nuspec
@@ -50,8 +50,8 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <!-- =============================== -->      
     <dependencies>
-      <dependency id="mingw" version="8.1.0" />
-      <dependency id="msys2" version="20190524.0.0.20191030" />
+      <dependency id="mingw" version="[8.1.0]" />
+      <dependency id="msys2" version="[20190524.0.0.20191030]" />
     </dependencies>
     <!--<provides>NOT YET IMPLEMENTED</provides>-->
     <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->

--- a/rnp/tools/chocolateyInstall.ps1
+++ b/rnp/tools/chocolateyInstall.ps1
@@ -3,15 +3,13 @@ $ErrorActionPreference = 'Stop';
 $osBitness = Get-ProcessorBits
 Write-Host "Detected osBitness=$osBitness"
 
-# $toolsDir        = Split-Path -Parent $MyInvocation.MyCommand.Definition
-# $packageDir      = Join-Path $toolsDir ".."
-
 # Include the Chocolatey compatibility scripts if available
-$thisScript = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$compatScript = $thisScript +  '.\ChocolateyCompat.ps1'
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$compatScript = $toolsDir +  '.\ChocolateyCompat.ps1'
 if (Test-Path $compatScript) {
     . ($compatScript)
 }
+# $packageDir      = Join-Path $toolsDir ".."
 
 # MSYS2 zips contain a root dir named msys32 or msys64
 # $msysName = '.' #shorten the path by exporting to the same folder
@@ -105,8 +103,8 @@ rebase
 execute "Installing Dependencies" `
         "pacman --noconfirm -S --needed bzip2 gzip mingw-w64-`$(uname -m)-json-c mingw-w64-`$(uname -m)-libbotan"
 
-Write-Output "Adding DLL path $dllPath"
-Install-ChocolateyPath -PathToInstall $dllPath
+# Install-ChocolateyPath -PathToInstall $dllPath
+Copy-Item "$dllPath\*.dll" $toolsDir -Force
 
 Write-Output "***********************************************************************************************"
 Write-Output "*"


### PR DESCRIPTION
Addresses #1 
Closes #2 

This version installs exact versions of `mingw` and `msys2` packages via dependencies,
then does libraries installation via pacman in msys2 environment and copies the resulting dlls to installation.
I successfully installed it on a different machine, but still need to closer investigate potential `pacman` packages updates (may need to specify exact versions there too) to get exact versions of DLLs as on the build machine, if this approach is at all satisfactory.

Also, need to support 32-bit version of `rnp.exe` and `rnpkeys.exe`. Currently, only 64-bit binaries are bundled.